### PR TITLE
VOTE-2042: update nginx version to match buildpack version

### DIFF
--- a/applications/nginx-waf/.docker/Dockerfile
+++ b/applications/nginx-waf/.docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG modsecurity_nginx_version="1.0.3"
-ARG nginx_version="1.25.4"
+ARG nginx_version="1.25.5"
 ARG ubuntu_version="jammy"
 
 FROM docker.io/ubuntu:${ubuntu_version}


### PR DESCRIPTION
[Update Nginx version to allow buildpack updates](https://cm-jira.usa.gov/browse/VOTE-2042)