### PR TITLE
VOTE-2923: Allow cores for subdomains of vote.gov and lando local environment for the vote.gov static site.

### DIFF
--- a/applications/nginx-waf/nginx/conf.d/default.conf
+++ b/applications/nginx-waf/nginx/conf.d/default.conf
@@ -92,6 +92,13 @@ server {
     rewrite ^([^.]*[^/])$ $1/;
     rewrite (.*)/$ $1/index.html last;
 
+    # Allow CORS for both http and https on subdomains of vote.gov and the local development domain
+    if ($http_origin ~* "^https://([a-z0-9-]+\\.)?vote\\.gov$" || $http_origin ~* "^https?://vote-gov.lndo.site$") {
+        add_header 'Access-Control-Allow-Origin' "$http_origin" always;
+        # Only allow GET requests
+        add_header 'Access-Control-Allow-Methods' 'GET';
+    }
+
     include nginx/snippets/proxy-to-static.conf;
     error_page 403 =404 @fourohfour;
   }


### PR DESCRIPTION
Allow cores for subdomains of vote.gov and lando local environment for the vote.gov static site.

@tt-gsa would you take a look at this change and let me know if this is correct.