### PR TITLE
VOTE-3373: Validate JSON files in cache before serving with Cloudfront

### DIFF
--- a/applications/nginx-waf/nginx/conf.d/default.conf
+++ b/applications/nginx-waf/nginx/conf.d/default.conf
@@ -100,7 +100,7 @@ server {
     add_header 'Access-Control-Allow-Origin' $cors_allow_origin always;
     add_header 'Access-Control-Allow-Methods' 'GET' always;
 
-    include nginx/snippets/proxy-to-static.conf;
+    include nginx/snippets/proxy-to-static-assets.conf;
     error_page 403 =404 @fourohfour;
     break;
   }

--- a/applications/nginx-waf/nginx/snippets/proxy-to-static-assets.conf.tmpl
+++ b/applications/nginx-waf/nginx/snippets/proxy-to-static-assets.conf.tmpl
@@ -1,0 +1,13 @@
+proxy_http_version      1.1;
+proxy_set_header        Connection \"\";
+proxy_set_header        Authorization '';
+proxy_set_header        Host ${static_bucket}.${static_fips_endpoint};
+proxy_hide_header       x-amz-id-2;
+proxy_hide_header       x-amz-request-id;
+proxy_hide_header       x-amz-meta-server-side-encryption;
+proxy_hide_header       x-amz-server-side-encryption;
+proxy_hide_header       Set-Cookie;
+proxy_ignore_headers    Set-Cookie;
+proxy_intercept_errors  on;
+add_header              Cache-Control no-cache;
+proxy_pass              https://${static_bucket}.${static_fips_endpoint};

--- a/locals.tf
+++ b/locals.tf
@@ -116,6 +116,10 @@ locals {
             destination = "${path.cwd}/applications/nginx-waf/nginx/snippets/proxy-to-static.conf"
           },
           {
+            source      = "${path.cwd}/applications/nginx-waf/nginx/snippets/proxy-to-static-assets.conf.tmpl"
+            destination = "${path.cwd}/applications/nginx-waf/nginx/snippets/proxy-to-static-assets.conf"
+          },
+          {
             source      = "${path.cwd}/applications/nginx-waf/nginx/snippets/proxy-to-app.conf.tmpl"
             destination = "${path.cwd}/applications/nginx-waf/nginx/snippets/proxy-to-app.conf"
           }
@@ -332,7 +336,7 @@ locals {
         port = var.mtls_port
 
         ## How much memory should it be using?
-        memory = 1024
+        memory = 970
       }
     }
     test = {


### PR DESCRIPTION
Change to the no-cache Cache-Control option for JSON files, causing Cloudfront to validate no changes (headers, which need to be dynamic) change for this request.